### PR TITLE
Fix background reference issue

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,7 +25,7 @@
 body {
   background-color: var(--black);
   color: var(--white);
-  background-image: url('./src/assets/background.png');
+  background-image: url('./assets/background.png');
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;


### PR DESCRIPTION
# Changes

Correct reference to background image to enable Vite to build correctly.

Currently, it's referencing `./src/assets/background.png`, however the file referencing this path is already in `src/`, resulting in it trying to get the file from `src/src/assets/background.png`. Remove extraneous `src/` at the beginning, allowing the build to complete successfully.

### Before

![image](https://github.com/user-attachments/assets/3ef4446f-364e-4651-8c51-b41788c30c03)

### After

![image](https://github.com/user-attachments/assets/98b24780-022e-484d-982c-027772760b81)
